### PR TITLE
Add Xahau

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1265,6 +1265,7 @@ All these constants are used as hardened derivation.
 | 19788      | 0x80004d4c                    | ML      | Mintlayer                         |
 | 20036      | 0x80004e44                    | XND     | ndau                              |
 | 21004      | 0x8000520c                    | C4EI    | c4ei                              |
+| 21337      | 0x80005359                    | XAH     | Xahau                             |
 | 21888      | 0x80005580                    | PAC     | Pactus                            |
 | 22504      | 0x800057e8                    | PWR     | PWRcoin                           |
 | 23000      | 0x800059d8                    | EPIC    | Epic Cash                         |


### PR DESCRIPTION
Adding XAH (Xahau network) with id `21337` (That's the native network ID, nice if it matches)

https://xahau.network